### PR TITLE
Implementazione conversione numeri 1-50

### DIFF
--- a/src/main/java/it/unipd/mtss/IntegerToRoman.java
+++ b/src/main/java/it/unipd/mtss/IntegerToRoman.java
@@ -17,8 +17,8 @@ public class IntegerToRoman {
      */
     public static String convert(int number){
         //Corrispondenza tra numeri romani e arabi (simboli singoli e casi sottrattivi);
-        int[] values={10, 9, 5, 4, 1};
-        String[] romanSymbols={"X", "IX", "V", "IV", "I"};
+        int[] values={50, 40, 10, 9, 5, 4, 1};
+        String[] romanSymbols={"L", "XL", "X", "IX", "V", "IV", "I"};
 
         StringBuilder result = new StringBuilder();
 

--- a/src/test/java/it/unipd/mtss/IntegerToRomanTest.java
+++ b/src/test/java/it/unipd/mtss/IntegerToRomanTest.java
@@ -98,12 +98,27 @@ public class IntegerToRomanTest {
     }
 
     @Test
-    public void testConvertfifteen(){
+    public void testConvertFifteen(){
         assertEquals("XV", IntegerToRoman.convert(15));
     }
 
     @Test
     public void testConvertTwenty(){
         assertEquals("XX", IntegerToRoman.convert(20));
+    }
+
+    @Test
+    public void testConvertThirtyfour(){
+        assertEquals("XXXIV", IntegerToRoman.convert(34));
+    }
+
+    @Test
+    public void testConvertFortyNine(){
+        assertEquals("XLIX", IntegerToRoman.convert(49));
+    }
+
+    @Test
+    public void testConvertFifty(){
+        assertEquals("L", IntegerToRoman.convert(50));
     }
 }


### PR DESCRIPTION
Closes #9 

- Aggiunti nuovi test per verificare la correttezza della conversione. I test per i numeri 49 e 50 falliscono correttamente nella fase rossa del ciclo TDD;
- Aggiornata la logica di conversione con l'aggiunta dei simboli L (50) e il caso sottrattivo XL (40);
- Effettuato merge da develop per garantire l'allineamento con le ultime modifiche.