### PR TITLE
Conversione numeri romani fino a 500

### DIFF
--- a/src/main/java/it/unipd/mtss/IntegerToRoman.java
+++ b/src/main/java/it/unipd/mtss/IntegerToRoman.java
@@ -17,8 +17,8 @@ public class IntegerToRoman {
      */
     public static String convert(int number){
         //Corrispondenza tra numeri romani e arabi (simboli singoli e casi sottrattivi);
-        int[] values={100, 90, 50, 40, 10, 9, 5, 4, 1};
-        String[] romanSymbols={"C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
+        int[] values={500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
+        String[] romanSymbols={"D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
 
         StringBuilder result = new StringBuilder();
 

--- a/src/test/java/it/unipd/mtss/IntegerToRomanTest.java
+++ b/src/test/java/it/unipd/mtss/IntegerToRomanTest.java
@@ -108,7 +108,7 @@ public class IntegerToRomanTest {
     }
 
     @Test
-    public void testConvertThirtyfour(){
+    public void testConvertThirtyFour(){
         assertEquals("XXXIV", IntegerToRoman.convert(34));
     }
 
@@ -130,5 +130,25 @@ public class IntegerToRomanTest {
     @Test
     public void testConvertNinetyNine(){
         assertEquals("XCIX", IntegerToRoman.convert(99));
+    }
+
+    @Test
+    public void testConvertOneHundred(){
+        assertEquals("C", IntegerToRoman.convert(100));
+    }
+
+    @Test
+    public void testConvertThreeHundredNinetyNine(){
+        assertEquals("CCCXCIX", IntegerToRoman.convert(399));
+    }
+
+    @Test
+    public void testConvertFourHundred(){
+        assertEquals("CD", IntegerToRoman.convert(400));
+    }
+
+    @Test
+    public void testConvertFiveHundred(){
+        assertEquals("D", IntegerToRoman.convert(500));
     }
 }


### PR DESCRIPTION
Closes #11 

- Implementazione di nuovi test per la conversione dei numeri fino a 500. I test falliscono correttamente per il nuovo simbolo D;
- Implementata logica di conversione fino a 500;
- Effettuato merge da develop per garantire l'allineamento con le ultime modifiche.