### PR TITLE
Implementazione stampa numeri fino al 500

### DIFF
--- a/src/main/java/it/unipd/mtss/RomanPrinter.java
+++ b/src/main/java/it/unipd/mtss/RomanPrinter.java
@@ -86,6 +86,9 @@ public class RomanPrinter {
                 case 'C':
                     matrix[i]=getAscii_C();
                     break;
+                case 'D':
+                    matrix[i]=getAscii_D();
+                    break;
                 default:
                     //Se è una lettera non supportara lancia un errore;
                     throw new IllegalArgumentException("Carattere non supportato: " + c);
@@ -171,6 +174,22 @@ public class RomanPrinter {
             "| |     ",
             "| |____ ",
             " \\_____|"
+        };
+    }
+
+    /**
+     * Fornisce il disegno Ascii della lettera D.
+     * 
+     * @return un array di 6 stringhe che rappresentano le righe della lettera D.
+     */
+    private static String[] getAscii_D(){
+        return new String[]{
+            " _____  ",
+            "|  __ \\ ",
+            "| |  | |",
+            "| |  | |",
+            "| |__| |",
+            "|_____/ "
         };
     }
 }

--- a/src/test/java/it/unipd/mtss/RomanPrinterTest.java
+++ b/src/test/java/it/unipd/mtss/RomanPrinterTest.java
@@ -211,4 +211,42 @@ public class RomanPrinterTest {
         //Assert:
         assertEquals(expected, result);
     }
+
+    @Test
+    public void testPrintAsciiFourHundred(){
+        //Arrange:
+        int number=400;
+        String expected= 
+            "  _____  _____  \n" +
+            " / ____||  __ \\ \n" +
+            "| |     | |  | |\n" +
+            "| |     | |  | |\n" +
+            "| |____ | |__| |\n" +
+            " \\_____||_____/ ";
+
+        //Act:
+        String result=RomanPrinter.print(number);
+
+        //Assert:
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testPrintAsciiFiveHundred(){
+        //Arrange:
+        int number=500;
+        String expected= 
+            " _____  \n" +
+            "|  __ \\ \n" +
+            "| |  | |\n" +
+            "| |  | |\n" +
+            "| |__| |\n" +
+            "|_____/ ";
+
+        //Act:
+        String result = RomanPrinter.print(number);
+
+        //Assert:
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
Addresses #13 

- Aggiunti test per la stampa del simbolo D. Falliscono correttamente con il giusto messaggio di errore (fase rossa);
- Aggiunta logica di stampa per il simbolo D (fase verde).